### PR TITLE
Don't show inactive items

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,20 +6,23 @@
 <% end %>
 <section class="grid-container">
   <% @items.each do |item| %>
-    <section class = "grid-item" id= 'item-<%=item.id%>'>
-      <h2> <%=link_to item.name, "/items/#{item.id}" %> </h2>
-      <p>Sold by: <%=link_to item.merchant.name, "/merchants/#{item.merchant.id}" %></p>
-      <img src= <%= item.image %>>
-      <p> <%= item.description unless @merchant%> </p>
-      <p>Price: <%=number_to_currency(item.price) %> </p>
-      <p>Inventory: <%= item.inventory %> </p>
-      <% if !@merchant %>
-      <% end %>
-      <% if item.active? %>
-        <p>Active</p>
-      <% else %>
-        <p>Inactive</p>
-      <% end %>
-    </section>
-    <% end %>
+  <% if item.active? %>
+      <section class = "grid-item" id= 'item-<%=item.id%>'>
+        <h2> <%=link_to item.name, "/items/#{item.id}" %> </h2>
+        <p>Sold by: <%=link_to item.merchant.name, "/merchants/#{item.merchant.id}" %></p>
+
+        <%= link_to image_tag(item.image), "/items/#{item.id}", class: "image-link-#{item.id}" %>
+        <p> <%= item.description unless @merchant%> </p>
+        <p>Price: <%=number_to_currency(item.price) %> </p>
+        <p>Inventory: <%= item.inventory %> </p>
+        <% if !@merchant %>
+        <% end %>
+        <% if item.active? %>
+          <p>Active</p>
+        <% else %>
+          <p>Inactive</p>
+        <% end %>
+      </section>
+    <% end  %>
+  <% end %>
 </section>

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -10,6 +10,32 @@ RSpec.describe "Items Index Page" do
 
       @pull_toy = @brian.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
       @dog_bone = @brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+
+      @user = User.create( name: 'Bob J',
+                          address: '123 Fake St',
+                          city: 'Denver',
+                          state: 'Colorado',
+                          zip: 80111,
+                          email: 'user@user.com',
+                          password: 'password')
+
+      @merchant = User.create( name: 'Bob J',
+                          address: '123 Fake St',
+                          city: 'Denver',
+                          state: 'Colorado',
+                          zip: 80111,
+                          email: 'user@user.com',
+                          password: 'password',
+                          role: 2)
+
+      @admin = User.create( name: 'Bob J',
+                          address: '123 Fake St',
+                          city: 'Denver',
+                          state: 'Colorado',
+                          zip: 80111,
+                          email: 'user@user.com',
+                          password: 'password',
+                          role: 3)
     end
 
     it "all items or merchant names are links" do
@@ -19,8 +45,8 @@ RSpec.describe "Items Index Page" do
       expect(page).to have_link(@tire.merchant.name)
       expect(page).to have_link(@pull_toy.name)
       expect(page).to have_link(@pull_toy.merchant.name)
-      expect(page).to have_link(@dog_bone.name)
-      expect(page).to have_link(@dog_bone.merchant.name)
+      # expect(page).to have_link(@dog_bone.name)
+      # expect(page).to have_link(@dog_bone.merchant.name)
     end
 
     it "I can see a list of all of the items "do
@@ -47,15 +73,43 @@ RSpec.describe "Items Index Page" do
         expect(page).to have_css("img[src*='#{@pull_toy.image}']")
       end
 
-      within "#item-#{@dog_bone.id}" do
-        expect(page).to have_link(@dog_bone.name)
-        expect(page).to have_content(@dog_bone.description)
-        expect(page).to have_content("Price: $#{@dog_bone.price}")
-        expect(page).to have_content("Inactive")
-        expect(page).to have_content("Inventory: #{@dog_bone.inventory}")
-        expect(page).to have_link(@brian.name)
-        expect(page).to have_css("img[src*='#{@dog_bone.image}']")
-      end
+      # within "#item-#{@dog_bone.id}" do
+      #   expect(page).to have_link(@dog_bone.name)
+      #   expect(page).to have_content(@dog_bone.description)
+      #   expect(page).to have_content("Price: $#{@dog_bone.price}")
+      #   expect(page).to have_content("Inactive")
+      #   expect(page).to have_content("Inventory: #{@dog_bone.inventory}")
+      #   expect(page).to have_link(@brian.name)
+      #   expect(page).to have_css("img[src*='#{@dog_bone.image}']")
+      # end
     end
+
+    it 'can show undisabled items to all users and images are now links' do
+
+      visit '/login'
+
+      fill_in :email, with: @user.email
+      fill_in :password, with: @user.password
+
+      click_button 'Login'
+
+      visit '/items'
+
+      expect(page).to have_content(@tire.name)
+      expect(page).to have_content(@pull_toy.name)
+      expect(page).to_not have_content(@dog_bone.name)
+
+      find(".image-link-#{@tire.id}").click
+
+
+      expect(current_path).to eq("/items/#{@tire.id}")
+    end
+# User Story 17, Items Index Page
+#
+# As a regular user on the system
+# I can visit the items catalog ("/items")
+# I see all items in the system except disabled items
+#
+# The item image is a link to that item's show page
   end
 end

--- a/spec/features/items/merchant_items_index_spec.rb
+++ b/spec/features/items/merchant_items_index_spec.rb
@@ -30,14 +30,8 @@ RSpec.describe "Merchant Items Index Page" do
         expect(page).to have_content("Inventory: #{@chain.inventory}")
       end
 
-      within "#item-#{@shifter.id}" do
-        expect(page).to have_content(@shifter.name)
-        expect(page).to have_content("Price: $#{@shifter.price}")
-        expect(page).to have_css("img[src*='#{@shifter.image}']")
-        expect(page).to have_content("Inactive")
-        expect(page).to_not have_content(@shifter.description)
-        expect(page).to have_content("Inventory: #{@shifter.inventory}")
-      end
+      expect(page).to_not have_css("#item-#{@shifter.id}")
+      
     end
   end
 end


### PR DESCRIPTION
Added new test to only show active items for visitors and users, added conditionals for users and visitors and refactored merchat_item_spec to hide inactive items for visitors 