### PR TITLE
User edit/update

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,8 +23,29 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+    @user = current_user
+  end
+
+  def update
+    user = current_user
+    user.update(user_update_params)
+    if user.save
+      flash[:success] = 'Your profile has been updated'
+      redirect_to '/profile'
+    else
+      flash.now[:error] = user.errors.full_messages.to_sentence
+      @user = user
+      render :edit
+    end
+  end
+
   private
     def user_params
       params.permit(:name,:address,:city,:state,:zip,:email,:password,:password_confirmation)
+    end
+
+    def user_update_params
+      params.permit(:name,:address,:city,:state,:zip,:email)
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,11 @@ class User < ApplicationRecord
   validates_presence_of :name, :address, :city, :state, :zip, :email
 
   validates :email, uniqueness: true
-  validates :password, presence: true, confirmation: { case_sensitive: true }
+  validates :password,
+            presence: true,
+            confirmation: { case_sensitive: true },
+            :if => :password
+
   has_secure_password
 
   enum role: [:default, :merchant_employee, :merchant_admin, :admin]

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,17 @@
+<h1>Change Your Information</h1>
+
+<%= form_tag "/profile/update", method: :patch do %>
+  <%= label_tag :name %>
+  <%= text_field_tag :name, @user.name %>
+  <%= label_tag :address, "Street Address" %>
+  <%= text_field_tag :address, @user.address  %>
+  <%= label_tag :city %>
+  <%= text_field_tag :city, @user.city %>
+  <%= label_tag :state %>
+  <%= text_field_tag :state, @user.state %>
+  <%= label_tag :zip %>
+  <%= text_field_tag :zip, @user.zip, pattern: "[0-9]{5}", title: 'Zip must be five digits' %>
+  <%= label_tag :email %>
+  <%= email_field_tag :email, @user.email %>
+  <%= submit_tag 'Update Information' %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,4 +9,4 @@
   <p>Email: <%= @user.email  %></p>
 </section>
 
-<%= link_to 'Edit Profile', "/users/#{@user.id}/edit" %>
+<%= link_to 'Edit Profile', "/profile/edit" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,10 @@ Rails.application.routes.draw do
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
+
   get '/profile', to: 'users#show'
+  get '/profile/edit', to: 'users#edit'
+  patch '/profile/update', to: 'users#update'
 
   get '/merchants', to: 'merchants#index'
   get '/merchants/new', to: 'merchants#new'

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe 'Edit Page' do
+  describe 'As a registered user (aka not a visitor)' do
+    describe 'As a user (role: 0) when I click edit profile' do
+      it 'takes me to a form with my info that I can edit' do
+        user = User.create( name: 'Bob J',
+                            address: '123 Fake St',
+                            city: 'Denver',
+                            state: 'Colorado',
+                            zip: 80111,
+                            email: 'user@user.com',
+                            password: 'password')
+
+        visit '/login'
+
+        fill_in :email, with: 'user@user.com'
+        fill_in :password, with: 'password'
+        click_button 'Login'
+
+        expect(current_path).to eq('/profile')
+
+        click_link 'Edit Profile'
+
+        expect(current_path).to eq('/profile/edit')
+
+        expect(find_field('Name').value).to eq(user.name)
+        expect(find_field('Address').value).to eq(user.address)
+        expect(find_field('City').value).to eq(user.city)
+        expect(find_field('State').value).to eq(user.state)
+        expect(find_field('Zip').value).to eq("#{user.zip}")
+        expect(find_field('Email').value).to eq(user.email)
+        expect(page).to_not have_content 'Password'
+
+        fill_in :address, with: "456 New Address"
+
+        click_button 'Update Information'
+
+        expect(current_path).to eq('/profile')
+        expect(page).to have_content('Your profile has been updated')
+        expect(page).to have_content('456 New Address')
+      end
+
+      it 'takes me to a form with my info that I can edit and does not update
+          if incomplete' do
+        user = User.create( name: 'Bob J',
+                            address: '123 Fake St',
+                            city: 'Denver',
+                            state: 'Colorado',
+                            zip: 80111,
+                            email: 'user@user.com',
+                            password: 'password')
+
+        visit '/login'
+
+        fill_in :email, with: 'user@user.com'
+        fill_in :password, with: 'password'
+        click_button 'Login'
+
+        expect(current_path).to eq('/profile')
+
+        click_link 'Edit Profile'
+
+        expect(current_path).to eq('/profile/edit')
+
+        expect(find_field('Name').value).to eq(user.name)
+        expect(find_field('Address').value).to eq(user.address)
+        expect(find_field('City').value).to eq(user.city)
+        expect(find_field('State').value).to eq(user.state)
+        expect(find_field('Zip').value).to eq("#{user.zip}")
+        expect(find_field('Email').value).to eq(user.email)
+        expect(page).to_not have_content 'Password'
+
+        fill_in :address, with: nil
+
+        click_button 'Update Information'
+
+        expect(page).to have_content("Address can't be blank")
+      end
+    end
+  end
+end


### PR DESCRIPTION
User Story 19, User Can Edit their Profile Data
- Edit/Update part of CRUD for Users
- Form added to new view file
- Model for User updated to add if presence of password so update actually updates
- Routes use /profile instead of /user because we have access to current_user from application_controller

Feature tests for updating and also sad path test for nil value in fields.