### PR TITLE
User edit unique email

### DIFF
--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -106,5 +106,34 @@ RSpec.describe 'Edit Page' do
         expect(page).to have_content("Address can't be blank")
       end
     end
+
+    it 'a user cannot edit their email to another user email' do
+      @users.each_with_index do |user, index|
+        visit '/login'
+
+        fill_in :email, with: user.email
+        fill_in :password, with: user.password
+        click_button 'Login'
+
+        visit '/profile'
+
+        click_link 'Edit Profile'
+
+        expect(current_path).to eq('/profile/edit')
+
+        expect(find_field('Name').value).to eq(user.name)
+        expect(find_field('Address').value).to eq(user.address)
+        expect(find_field('City').value).to eq(user.city)
+        expect(find_field('State').value).to eq(user.state)
+        expect(find_field('Zip').value).to eq("#{user.zip}")
+        expect(find_field('Email').value).to eq(user.email)
+        expect(page).to_not have_content 'Password'
+
+        fill_in :email, with: @users[index-1].email
+        click_button 'Update Information'
+
+        expect(page).to have_content("Email has already been taken")
+      end
+    end
   end
 end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -2,24 +2,58 @@ require 'rails_helper'
 
 RSpec.describe 'Edit Page' do
   describe 'As a registered user (aka not a visitor)' do
-    describe 'As a user (role: 0) when I click edit profile' do
-      it 'takes me to a form with my info that I can edit' do
-        user = User.create( name: 'Bob J',
-                            address: '123 Fake St',
-                            city: 'Denver',
-                            state: 'Colorado',
-                            zip: 80111,
-                            email: 'user@user.com',
-                            password: 'password')
+    before(:each) do
+      user = User.create(
+        name: 'Bob J',
+        address: '123 Fake St',
+        city: 'Denver',
+        state: 'Colorado',
+        zip: 80111,
+        email: 'user@user.com',
+        password: 'password',
+      )
+      merchant_employee = User.create(
+        name: 'Bob J',
+        address: '123 Fake St',
+        city: 'Denver',
+        state: 'Colorado',
+        zip: 80111,
+        email: 'merchemp@merchemp.com',
+        password: 'password',
+        role: 1
+      )
+      merchad = User.create(
+        name: 'Bob J',
+        address: '123 Fake St',
+        city: 'Denver',
+        state: 'Colorado',
+        zip: 80111,
+        email: 'merchad@merchad.com',
+        password: 'password',
+        role: 2
+      )
+      admin = User.create(
+        name: 'Bob J',
+        address: '123 Fake St',
+        city: 'Denver',
+        state: 'Colorado',
+        zip: 80111,
+        email: 'admin@admin.com',
+        password: 'password',
+        role: 3
+      )
+      @users = [user, merchant_employee, merchad, admin]
+    end
 
+    it 'takes me to a form with my info that I can edit' do
+      @users.each do |user|
         visit '/login'
 
-        fill_in :email, with: 'user@user.com'
-        fill_in :password, with: 'password'
+        fill_in :email, with: user.email
+        fill_in :password, with: user.password
         click_button 'Login'
 
-        expect(current_path).to eq('/profile')
-
+        visit '/profile'
         click_link 'Edit Profile'
 
         expect(current_path).to eq('/profile/edit')
@@ -40,24 +74,18 @@ RSpec.describe 'Edit Page' do
         expect(page).to have_content('Your profile has been updated')
         expect(page).to have_content('456 New Address')
       end
+    end
 
-      it 'takes me to a form with my info that I can edit and does not update
-          if incomplete' do
-        user = User.create( name: 'Bob J',
-                            address: '123 Fake St',
-                            city: 'Denver',
-                            state: 'Colorado',
-                            zip: 80111,
-                            email: 'user@user.com',
-                            password: 'password')
-
+    it 'takes me to a form with my info that I can edit and does not update
+        if incomplete' do
+      @users.each do |user|
         visit '/login'
 
-        fill_in :email, with: 'user@user.com'
-        fill_in :password, with: 'password'
+        fill_in :email, with: user.email
+        fill_in :password, with: user.password
         click_button 'Login'
 
-        expect(current_path).to eq('/profile')
+        visit '/profile'
 
         click_link 'Edit Profile'
 


### PR DESCRIPTION
User Story 21, User Editing Profile Data must have unique Email address

- Test to edit profile now loops through all user roles
- Use each_with_index to try to update a user emails to another user's email with test

- Feature test passes