### PR TITLE
Move visitor login/register cart message inside cart_empty?

### DIFF
--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -1,13 +1,12 @@
 <h1>Cart</h1>
 
-<% unless current_user %>
-  <section id = 'visitor-requirement'>
-    <p>Please <%= link_to 'Login', '/login' %> or <%= link_to 'Register', '/register' %> to checkout</p>
-  </section>
-<% end %>
-
 <% if !@items.empty? %>
 <center>
+  <% unless current_user %>
+    <section id = 'visitor-requirement'>
+      <p>Please <%= link_to 'Login', '/login' %> or <%= link_to 'Register', '/register' %> to checkout</p>
+    </section>
+  <% end %>
 <table class = "cart-items">
   <tr>
     <th>Item</th>


### PR DESCRIPTION
When clicking through development, it makes more sense to only show "Please login or register to continue" when there are items in the cart and a checkout link is available.