### PR TITLE
Merchant delete item 37

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -27,6 +27,13 @@ class Merchant::ItemsController < Merchant::BaseController
     redirect_to '/merchant/items'
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    item.delete
+    flash[:success] = "#{item.name} has been deleted"
+    redirect_to '/merchant/items'
+  end
+
   private
 
     def fufill_update(item_order, item, order)

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -21,6 +21,9 @@
         <% elsif !item.active? && current_merchant_admin? %>
           <%= button_to 'Activate', "/merchant/items/#{item.id}/enable", method: :patch %>
         <% end %>
+        <% if item.no_orders? && current_merchant_admin? %>
+          <%= button_to 'Delete Item', "/merchant/items/#{item.id}", method: :delete %>
+        <% end  %>
       </section>
     <% end  %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
     patch '/orders/:order_id/items/:item_id', to: 'items#fulfill'
     patch '/items/:id/disable', to: 'items#deactivate'
     patch '/items/:id/enable', to: 'items#activate'
+    delete '/items/:id', to: 'items#destroy'
   end
 
   get '/admin', to: 'admin/dashboard#index'

--- a/spec/features/users/merchant/items/index_spec.rb
+++ b/spec/features/users/merchant/items/index_spec.rb
@@ -6,6 +6,7 @@ describe 'as a merchant admin' do
       @chester_the_merchant = Merchant.create!(name: "Chester's Shop", address: '456 Terrier Rd.', city: 'Richmond', state: 'VA', zip: 23137)
       @merchant_admin = @chester_the_merchant.users.create!(name: 'Boss', address: '123 Fake St', city: 'Denver', state: 'Colorado', zip: 80111, email: 'boss@boss.com', password: 'password', role: 2 )
       @merchant_employee = @chester_the_merchant.users.create!(name: 'Drone', address: '123 Fake St', city: 'Denver', state: 'Colorado', zip: 80111, email: 'employee@employee.com', password: 'password', role: 1 )
+      @user = User.create!(name: 'Customer Sally', address: '123 Fake St', city: 'Denver', state: 'Colorado', zip: 80111, email: 'user@user.com', password: 'password' )
 
 
       @pull_toy = @chester_the_merchant.items.create!(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
@@ -68,6 +69,43 @@ describe 'as a merchant admin' do
 
       within "#item-#{@ball.id}" do
         expect(page).to_not have_button('Activate')
+      end
+    end
+
+    it 'has a button/link to delete an item that has never been ordered' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_admin)
+      visit '/merchant/items'
+
+      within "#item-#{@pull_toy.id}" do
+        expect(page).to have_button('Delete Item')
+      end
+
+      order = @user.orders.create!(name: @user.name, address: @user.address, city: @user.city, state: @user.state, zip: @user.zip, user_id: @user.id)
+      @item_order_1 = order.item_orders.create!(item: @pull_toy, price: @pull_toy.price, quantity: 2)
+
+      visit '/merchant/items'
+
+      within "#item-#{@pull_toy.id}" do
+        expect(page).to_not have_button('Delete Item')
+      end
+
+      within "#item-#{@dog_bone.id}" do
+        click_button('Delete Item')
+      end
+
+      expect(current_path).to eq('/merchant/items')
+      expect(page).to have_content("Dog Bone has been deleted")
+
+      expect(page).to_not have_css("#item-#{@dog_bone.id}")
+
+    end
+
+    it "Can not delete item as a merchant_employee" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_employee)
+      visit '/merchant/items'
+
+      within "#item-#{@pull_toy.id}" do
+        expect(page).to_not have_button('Delete Item')
       end
     end
   end


### PR DESCRIPTION
A merchant admin can delete it's items that have not been ordered.
A merchant employee is prevented from doing so by having the delete button hidden from view

Feature test added and all tests pass