### PR TITLE
Admin ship order - User story 43

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,8 @@
+class Admin::OrdersController < Admin::BaseController
+
+  def ship
+    order = Order.find(params[:id])
+    order.update(status: 'shipped')
+    redirect_to '/admin'
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -7,6 +7,9 @@
       <p>Order #: <%= order.id %></p>
       <p>Order Date: <%= order.created_date %></p>
       <p>Order Status: <%= order.status %></p>
+      <% if order.status == 'packaged' %>
+        <%= button_to "Ship Order", "/admin/orders/#{order.id}/ship", method: :patch %>
+      <% end %>
     </section>
   <% end %>
 </section>

--- a/app/views/profile/orders/show.html.erb
+++ b/app/views/profile/orders/show.html.erb
@@ -63,4 +63,6 @@
   <p>Total Items: <%= @order.item_count %></p>
 </section>
 
-<%= button_to 'Cancel Order', "/profile/orders/#{@order.id}", method: :patch %>
+<% unless @order.status == 'shipped' || @order.status == 'cancelled'  %>
+  <%= button_to 'Cancel Order', "/profile/orders/#{@order.id}", method: :patch %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,5 +64,10 @@ Rails.application.routes.draw do
     get '/orders/:id', to: 'orders#show'
   end
 
-  get '/admin', to: 'admin/dashboard#index'
+  namespace :admin do
+    get '/', to: 'dashboard#index'
+    patch '/orders/:id/ship', to: 'orders#ship'
+  end
+
+
 end

--- a/spec/features/users/admin/orders/index_spec.rb
+++ b/spec/features/users/admin/orders/index_spec.rb
@@ -63,24 +63,31 @@ describe 'As an Admin on my admin dashboard' do
 
       expect(page).to have_content('packaged')
     end
+  end
+
+  it 'has a button to ship an order next to packaged orders' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+    visit '/admin'
+
+    within "#order-#{@order_3.id}" do
+      expect(page).to_not have_button("Ship Order")
+    end
+
+    within "#order-#{@order_4.id}" do
+      expect(page).to have_button("Ship Order")
+      click_button("Ship Order")
+    end
+
+    within "#order-#{@order_4.id}" do
+      expect(page).to have_content('shipped')
+      expect(page).to_not have_button("Ship Order")
+    end
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    visit "/profile/orders/#{@order_4.id}"
+
+    expect(page).to have_content('Shipped')
+    expect(page).to_not have_button "Cancel Order"
 
   end
 end
-
-
-
-# As an admin user
-# When I visit my admin dashboard ("/admin")
-# Then I see all orders in the system.
-# For each order I see the following information:
-#
-# - user who placed the order, which links to admin view of user profile
-# - order id
-# - date the order was created
-#
-# Orders are sorted by "status" in this order:
-#
-# - packaged
-# - pending
-# - shipped
-# - cancelled


### PR DESCRIPTION
Add button for an admin to ship an order. It updates the status of the order and disables the cancel button for the user on their order show page.

All tests passing.