### PR TITLE
Admin disable/enable merchant - User story 44

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,18 @@
+class Admin::MerchantsController < Admin::BaseController
+
+  def show
+    @merchant = Merchant.find(params[:id])
+  end
+
+  def disable
+    merchant = Merchant.find(params[:id])
+    merchant.update(active?: false)
+    redirect_to '/merchants'
+  end
+
+  def enable
+    merchant = Merchant.find(params[:id])
+    merchant.update(active?: true)
+    redirect_to '/merchants'
+  end
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -11,6 +11,7 @@ class Merchant <ApplicationRecord
                         :state,
                         :zip
 
+  validates_inclusion_of :active?, :in => [true, false]
 
   def no_orders?
     item_orders.empty?

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,0 +1,1 @@
+<h1><%= @merchant.name %></h1>

--- a/app/views/merchants/index.html.erb
+++ b/app/views/merchants/index.html.erb
@@ -2,8 +2,18 @@
 <p align="center"><%= link_to "New Merchant", "/merchants/new" %></p>
 <section class = "grid-container">
   <% @merchants.each do |merchant|%>
-    <section class = "grid-item">
-      <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
+    <section class = "grid-item" id="merchant-<%= merchant.id %>">
+      <% if current_admin? %>
+      <h2><%=link_to merchant.name, "/admin/merchants/#{merchant.id}"%></h2>
+      <p><%= merchant.city %>, <%= merchant.state %></p>
+        <% if merchant.active? %>
+          <%= button_to 'Disable', "/admin/merchants/#{merchant.id}/disable", method: :patch %>
+        <% else %>
+          <%= button_to 'Enable', "/admin/merchants/#{merchant.id}/enable", method: :patch %>
+        <% end %>
+      <% else %>
+        <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
+      <% end %>
     </section>
   <% end %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,9 @@ Rails.application.routes.draw do
   namespace :admin do
     get '/', to: 'dashboard#index'
     patch '/orders/:id/ship', to: 'orders#ship'
+    get '/merchants/:id', to: 'merchants#show'
+    patch '/merchants/:id/disable', to: 'merchants#disable'
+    patch '/merchants/:id/enable', to: 'merchants#enable'
   end
 
 

--- a/db/migrate/20191029200105_add_active_to_merchants.rb
+++ b/db/migrate/20191029200105_add_active_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddActiveToMerchants < ActiveRecord::Migration[5.1]
+  def change
+    add_column :merchants, :active?, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191029173716) do
+ActiveRecord::Schema.define(version: 20191029200105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20191029173716) do
     t.integer "zip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active?", default: true
   end
 
   create_table "orders", force: :cascade do |t|

--- a/spec/features/users/admin/merchants/index_spec.rb
+++ b/spec/features/users/admin/merchants/index_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe 'As an Admin on the /merchants index' do
+  before(:each) do
+    @chester_the_merchant = Merchant.create!(name: "Chester's Shop", address: '456 Terrier Rd.', city: 'Richmond', state: 'VA', zip: 23137)
+    @bike_shop = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+
+
+    @user = User.create!(name: 'Customer Sally', address: '123 Fake St', city: 'Denver', state: 'Colorado', zip: 80111, email: 'user@user.com', password: 'password' )
+    @merchant_employee = @chester_the_merchant.users.create!(name: 'Drone', address: '123 Fake St', city: 'Denver', state: 'Colorado', zip: 80111, email: 'employee@employee.com', password: 'password', role: 1 )
+    @merchant_admin = @chester_the_merchant.users.create!(name: 'Boss', address: '123 Fake St', city: 'Denver', state: 'Colorado', zip: 80111, email: 'boss@boss.com', password: 'password', role: 2 )
+    @admin = User.create!(name: 'Admin Foxy', address: '123 Fake St', city: 'Denver', state: 'Colorado', zip: 80111, email: 'admin@admin.com', password: 'password', role: 3)
+
+    # @pull_toy = @chester_the_merchant.items.create!(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
+    # @dog_bone = @chester_the_merchant.items.create!(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+
+  end
+
+  it 'I see all the merchants with an option to disable/enable the merchant' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+    visit '/merchants'
+
+    within "#merchant-#{@chester_the_merchant.id}" do
+      expect(page).to have_link("Chester's Shop")
+      expect(page).to have_content("Richmond, VA")
+      expect(page).to have_button('Disable')
+    end
+
+    within "#merchant-#{@bike_shop.id}" do
+      expect(page).to have_link("Meg's Bike Shop")
+      expect(page).to have_content("Denver, CO")
+      expect(page).to have_button('Disable')
+    end
+
+    within "#merchant-#{@chester_the_merchant.id}" do
+      click_button 'Disable'
+      expect(page).to have_button 'Enable'
+      click_button 'Enable'
+      expect(page).to have_button 'Disable'
+    end
+
+    within "#merchant-#{@chester_the_merchant.id}" do
+      click_link("Chester's Shop")
+    end
+
+    expect(current_path).to eq("/admin/merchants/#{@chester_the_merchant.id}")
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    visit '/merchants'
+
+    within "#merchant-#{@chester_the_merchant.id}" do
+      expect(page).to_not have_button('Disable')
+    end
+
+    within "#merchant-#{@bike_shop.id}" do
+      expect(page).to_not have_button('Disable')
+    end
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -70,5 +70,6 @@ describe Merchant, type: :model do
       expected = [order_1, order_2]
       expect(@meg.pending_orders).to eq(expected)
     end
+
   end
 end


### PR DESCRIPTION
Add button for admin to disable/enable merchant from the /merchants index page. Conditionally render information for current_admin and all other users in the merchants index view.

Add new active? column to merchants resource.

New routes and controller actions within the /admin namespace for merchants#enable and merchants#disable.

All tests passing.