### PR TITLE
Password Edit Update

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,13 +40,18 @@ class UsersController < ApplicationController
   end
 
   def update_password
-    current_user.update(password_params)
-    if current_user.save
-      flash[:success] = 'Your password has been changed.'
-      redirect_to '/profile'
-    else
-      flash.now[:error] = current_user.errors.full_messages.first
+    if password_blank(password_params)
+      flash.now[:error] = "Password can't be blank"
       render :edit_password
+    else
+      current_user.update(password_params)
+      if current_user.save
+        flash[:success] = 'Your password has been changed.'
+        redirect_to '/profile'
+      else
+        flash.now[:error] = current_user.errors.full_messages.first
+        render :edit_password
+      end
     end
   end
 
@@ -61,5 +66,10 @@ class UsersController < ApplicationController
 
     def password_params
       params.permit(:password,:password_confirmation)
+    end
+
+    def password_blank(password_params)
+      return true if password_params[:password].length == 0
+      false
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,8 @@
 class User < ApplicationRecord
-  validates_presence_of :name, :address, :city, :state, :zip, :email
+  validates_presence_of :name, :address, :city, :state, :zip, :email, :password_digest
 
   validates :email, uniqueness: true
-  validates :password,
-            presence: true,
-            length: { minimum: 2 },
-            confirmation: { case_sensitive: true },
-            :if => :password
+  validates :password, confirmation: { case_sensitive: true }
 
   has_many :orders
   belongs_to :merchant, optional: true

--- a/app/views/users/edit_password.html.erb
+++ b/app/views/users/edit_password.html.erb
@@ -2,8 +2,8 @@
 
 <%= form_tag '/profile/update-password', method: :patch do %>
   <%= label_tag :password %>
-  <%= password_field_tag :password, ' ' %>
+  <%= password_field_tag :password, nil, required: true %>
   <%= label_tag :password_confirmation, 'Password Confirmation' %>
-  <%= password_field_tag :password_confirmation, ' ' %>
+  <%= password_field_tag :password_confirmation, nil, required: true %>
   <%= submit_tag 'Update Password' %>
 <% end %>


### PR DESCRIPTION
When a logged-in user changes a password, if they leave the fields blank, it no longer updates the password to an empty string.

In the model, the conditional `if :password` was removed and a password_digest is now required.

The users_controller now checks if the password params are blank. Also the form requires a password on the front end as well.

master branch last merged into this branch at 8:15pm on 10/29 - no conflicts

All tests passing. Also tested in `rails s` to confirm practical functionality.