### PR TITLE
Item quantity update User story 27 

### DIFF
--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -29,6 +29,7 @@ class Profile::OrdersController < ApplicationController
   def update
     order = Order.find(params[:id])
     order.update(status: 'cancelled')
+    order.return_fulfilled_item_stock
     order.unfulfilled_item_orders
     flash[:notice] = "Order #: #{order.id} has been cancelled"
     redirect_to '/profile'

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -29,6 +29,15 @@ class Order <ApplicationRecord
     end
   end
 
+  def return_fulfilled_item_stock
+    fulfilled_item_orders = item_orders.where(status: 'fulfilled')
+    fulfilled_item_orders.each do |item_order|
+      current_inventory = item_order.item.inventory
+      quantity_ordered = item_order.quantity
+      item_order.item.update(inventory: (current_inventory + quantity_ordered))
+    end
+  end
+
   def items_of_merchant(merchant_id)
     items.where(merchant_id: merchant_id)
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -63,6 +63,7 @@ describe Order, type: :model do
     it "when cancelled all it's item orders status updates to unfulfilled" do
       expect(@item_order_1.status).to eq('pending')
       expect(@item_order_2.status).to eq('pending')
+
       @order_1.unfulfilled_item_orders
       expect(@item_order_1.status).to eq('unfulfilled')
       expect(@item_order_2.status).to eq('unfulfilled')
@@ -84,6 +85,13 @@ describe Order, type: :model do
       end
 
       expect(@order_1.all_items_fulfilled?).to be_truthy
+    end
+
+    it 'it increases the item inventory by the quantity ordered for a cancelled order' do
+      item_order_5 = @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2, status: 'fulfilled')
+      @order_1.return_fulfilled_item_stock
+
+      expect(Item.find(@tire.id).inventory).to eq(14)
     end
   end
 


### PR DESCRIPTION
Return item inventory to pre-fulfilled stock when a user cancels an order.

Feature test fully mimics process of fulfillment for part of an order and user cancelling.
Model test simply adds inventory back to items for fulfilled item_orders

All tests passing 100% coverage