### PR TITLE
Reroute link next to the edit header for editing merchants

### DIFF
--- a/app/views/merchant/dashboard/edit.html.erb
+++ b/app/views/merchant/dashboard/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Edit <%=link_to current_user.merchant.name, "/merchant/merchants/#{current_user.merchant.id}" %></h1>
+<h1>Edit <%=link_to current_user.merchant.name, "/merchants/#{current_user.merchant.id}" %></h1>
 <center>
   <%= form_tag "/merchant/merchants/#{current_user.merchant.id}", method: :patch do %>
     <%= label_tag :name %>


### PR DESCRIPTION
Reroute the link next to the Edit Merchant header for editing merchants to the proper merchant.